### PR TITLE
Fix the bad (NoneType) parent object errors

### DIFF
--- a/FGA_VectorFields/vf_editor.py
+++ b/FGA_VectorFields/vf_editor.py
@@ -474,7 +474,7 @@ class toggle_vectorfieldvelocities(bpy.types.Operator):
 			if context.window_manager.vf_showingvelocitylines < 1:
 				volmesh = context.active_object
 				
-				temploc = volmesh.parent.location
+				temploc = volmesh.location
 				vf_coords = [(Vector(v.vcoord) + temploc) for v in volmesh.custom_vectorfield]
 				vf_velocities = [Vector(v.vvelocity) for v in volmesh.custom_vectorfield]
 				vf_DrawVelocities = [Vector((0.0,0.0,0.0)) for i in range(len(volmesh.custom_vectorfield) * 2)]

--- a/FGA_VectorFields/vf_io.py
+++ b/FGA_VectorFields/vf_io.py
@@ -16,7 +16,7 @@ def build_importedVectorField(tempvelList, tempOffset):
 	for i in range(len(tempvelList)):
 		volmesh.custom_vectorfield[i].vvelocity = tempvelList[i]
 	
-	volmesh.parent.location = volmesh.parent.location + tempOffset
+	volmesh.location = volmesh.location + tempOffset
 
 # read data from file
 def parse_fgafile(self, context):
@@ -117,7 +117,7 @@ def write_fgafile(self, exportvol):
 		)
 	else:
 		if useoffset:
-			offsetvect = exportvol.parent.location
+			offsetvect = exportvol.location
 			fw("\n%f,%f,%f," % (
 				(((tempDensity[0] * -0.5) * fgascale[0]) + (offsetvect[0])) * self.exportvf_scale,
 				(((tempDensity[1] * -0.5) * fgascale[1]) + (offsetvect[1])) * self.exportvf_scale,


### PR DESCRIPTION
Remove the upwards scoping to the object's parent since it has been NoneType.

This may be a bug due to the way Blender 2.8 changed the scene collections.

Fixes issue #15.